### PR TITLE
Video Conference Integration - Frontend

### DIFF
--- a/src/views/SOARModuleAnalysis.vue
+++ b/src/views/SOARModuleAnalysis.vue
@@ -129,6 +129,14 @@
             <div v-else v-on:click="selectWorkshop(inPersonWorkshop.name)">{{inPersonWorkshop.name}}</div>
           </div>
         </div>
+        <div class="medium-space"></div>
+        <div  v-if="'videoConferenceDate' in selectedCompany.inPersonWorkshops[SOARModule]" class="notice-message">
+          In-person workshop scheduled for:
+          (include zoom link to workshop)
+        </div>
+        <div v-else v-on:click="scheduleVideoConference()" class="general-select">
+          Schedule in person workshop
+        </div>
       </div>
       <div class="medium-space"></div>
       <div v-on:click="saveWorkshopState()">
@@ -441,6 +449,27 @@ export default class SOARModuleAnalysis extends Vue {
     }
     const response = await axios.post(url + "/saveWorkshopState", data)
     this.selectedCompany.inPersonWorkshops = response.data.inPersonWorkshops
+  }
+  scheduleVideoConference () {
+    // TODO:
+    // 1. Open a modal allowing the user to select a date and time
+    // 2. Once selected, submit button calls submitScheduleVideoConference
+  }
+  submitScheduleVideoConference () {
+    // TODO:
+    // 1. When
+    // 2. Send request to backend scheduleVideoConference
+    //    data must contain: companyId (this.selectedCompany.uuid), moduleId (this.SOARModule)
+    // e.g.:
+    // const data = {
+    //   companyId: this.selectedCompany.uuid,
+    //   moduleId: this.SOARModule,
+    //   datetime: <selected date and time>
+    // }
+    // const response = await axios.post(url + "/scheduleVideoConference", data)
+    // When response received, update the current selectedCompany to the received one
+    // and that should contain the new "videoConferenceDate" key in the inPersonWorkshops key of
+    // the company object
   }
 }
 </script>

--- a/src/views/SOARModuleAnalysis.vue
+++ b/src/views/SOARModuleAnalysis.vue
@@ -452,7 +452,8 @@ export default class SOARModuleAnalysis extends Vue {
   }
   scheduleVideoConference () {
     // TODO:
-    // 1. Open a modal allowing the user to select a date and time
+    // 1. Open a modal allowing the user to select a date and time, and an optional name for the
+    // video conference meeting
     // 2. Once selected, submit button calls submitScheduleVideoConference
   }
   submitScheduleVideoConference () {
@@ -464,6 +465,7 @@ export default class SOARModuleAnalysis extends Vue {
     // const data = {
     //   companyId: this.selectedCompany.uuid,
     //   moduleId: this.SOARModule,
+    //   conferenceName: "Video conference 1"
     //   datetime: <selected date and time>
     // }
     // const response = await axios.post(url + "/scheduleVideoConference", data)

--- a/src/views/SOARModuleAnalysis.vue
+++ b/src/views/SOARModuleAnalysis.vue
@@ -135,7 +135,7 @@
           (include zoom link to workshop)
         </div>
         <div v-else v-on:click="scheduleVideoConference()" class="general-select">
-          Schedule in person workshop
+          Schedule video conference
         </div>
       </div>
       <div class="medium-space"></div>


### PR DESCRIPTION
The user must be able to schedule a new zoom meeting at the end of the in-person workshops. Once the event is scheduled, the date / time and event name is saved.

**Starting instructions are included in the initial commit of this branch.**

### Acceptance Criteria:
- User can schedule a new in-person workshop video conference for a specified date and time, including a name for the conference event and zoom link to join it.
- Once it is scheduled, all users will be able to get access the zoom link in their home page
- The admin can schedule an unlimited number of video conferences, and delete / edit any of them as they please

**The desired order of milestones are:**
- User can create as many video conference events as desired
- User can delete each video conference event
- User can edit each video conference event